### PR TITLE
Change postgres storage type to gp2 and option for encryption

### DIFF
--- a/templates/kong-elb-postgres-optional-vpc-new-hvm.template
+++ b/templates/kong-elb-postgres-optional-vpc-new-hvm.template
@@ -50,6 +50,21 @@
       "Type": "String",
       "Default": ""
     },
+    "DBStorageEncrypted" : {
+      "Default" : false,
+      "Description" : "Specifies whether the DB instance is encrypted",
+      "Type" : "String",
+      "AllowedValues" : [ true, false ]
+    },
+    "DBStorageType" : {
+      "Description": "Storage Type for RDS volume",
+      "Type": "String",
+      "Default": "gp2",
+      "AllowedValues": [
+        "gp2",
+        "standard"
+      ]
+    },
     "DBUsername": {
       "Default": "kong",
       "Description" : "The database admin account username",
@@ -507,7 +522,8 @@
           ]
         },
         "MultiAZ" : { "Ref" : "DBMultiAZ" },
-        "StorageType" : "gp2",
+        "StorageEncrypted" : { "Ref" : "DBStorageEncrypted" },
+        "StorageType" : { "Ref" : "DBStorageType" },
         "VPCSecurityGroups": [
           {
             "Ref": "DBSecurityGroup"

--- a/templates/kong-elb-postgres-optional-vpc-new-hvm.template
+++ b/templates/kong-elb-postgres-optional-vpc-new-hvm.template
@@ -507,6 +507,7 @@
           ]
         },
         "MultiAZ" : { "Ref" : "DBMultiAZ" },
+        "StorageType" : "gp2",
         "VPCSecurityGroups": [
           {
             "Ref": "DBSecurityGroup"

--- a/templates/kong-elb-postgres-optional-vpc-optional-hvm.template
+++ b/templates/kong-elb-postgres-optional-vpc-optional-hvm.template
@@ -595,6 +595,7 @@
           ]
         },
         "MultiAZ" : { "Ref" : "DBMultiAZ" },
+        "StorageType" : "gp2",
         "VPCSecurityGroups": [
           {
             "Ref": "DBSecurityGroup"

--- a/templates/kong-elb-postgres-optional-vpc-optional-hvm.template
+++ b/templates/kong-elb-postgres-optional-vpc-optional-hvm.template
@@ -130,6 +130,21 @@
       "Type": "String",
       "Default": ""
     },
+    "DBStorageEncrypted" : {
+      "Default" : false,
+      "Description" : "Specifies whether the DB instance is encrypted",
+      "Type" : "String",
+      "AllowedValues" : [ true, false ]
+    },
+    "DBStorageType" : {
+      "Description": "Storage Type for RDS volume",
+      "Type": "String",
+      "Default": "gp2",
+      "AllowedValues": [
+        "gp2",
+        "standard"
+      ]
+    },
     "SSHLocation": {
       "Description": "The IP address range that can be used to SSH to the Kong and Cassandra EC2 instances",
       "Type": "String",
@@ -595,7 +610,8 @@
           ]
         },
         "MultiAZ" : { "Ref" : "DBMultiAZ" },
-        "StorageType" : "gp2",
+        "StorageEncrypted" : { "Ref" : "DBStorageEncrypted" },
+        "StorageType" : { "Ref" : "DBStorageType" },
         "VPCSecurityGroups": [
           {
             "Ref": "DBSecurityGroup"

--- a/templates/kong-elb-postgres-optional-vpc-optional-pv.template
+++ b/templates/kong-elb-postgres-optional-vpc-optional-pv.template
@@ -130,6 +130,21 @@
       "Type": "String",
       "Default": ""
     },
+    "DBStorageEncrypted" : {
+      "Default" : false,
+      "Description" : "Specifies whether the DB instance is encrypted",
+      "Type" : "String",
+      "AllowedValues" : [ true, false ]
+    },
+    "DBStorageType" : {
+      "Description": "Storage Type for RDS volume",
+      "Type": "String",
+      "Default": "gp2",
+      "AllowedValues": [
+        "gp2",
+        "standard"
+      ]
+    },
     "SSHLocation": {
       "Description": "The IP address range that can be used to SSH to the Kong and Cassandra EC2 instances",
       "Type": "String",
@@ -584,7 +599,8 @@
           ]
         },
         "MultiAZ" : { "Ref" : "DBMultiAZ" },
-        "StorageType" : "gp2",
+        "StorageEncrypted" : { "Ref" : "DBStorageEncrypted" },
+        "StorageType" : { "Ref" : "DBStorageType" },
         "VPCSecurityGroups": [
           {
             "Ref": "DBSecurityGroup"

--- a/templates/kong-elb-postgres-optional-vpc-optional-pv.template
+++ b/templates/kong-elb-postgres-optional-vpc-optional-pv.template
@@ -584,6 +584,7 @@
           ]
         },
         "MultiAZ" : { "Ref" : "DBMultiAZ" },
+        "StorageType" : "gp2",
         "VPCSecurityGroups": [
           {
             "Ref": "DBSecurityGroup"


### PR DESCRIPTION
AWS considers magentic storage `previous generation`. This PR defaults to general purpose SSD for RDS Postgres.

Docs -
http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html
https://aws.amazon.com/ebs/previous-generation/
